### PR TITLE
feat(core): Implement Phase A Biopython descriptors (Track B)

### DIFF
--- a/docs/to_do/biophysical_descriptors/BIOPHYSICAL_IMPLEMENTATION_SPECS.md
+++ b/docs/to_do/biophysical_descriptors/BIOPHYSICAL_IMPLEMENTATION_SPECS.md
@@ -69,7 +69,7 @@ From Novo paper Table S1, marked with (*) = Biopython:
 
 ### 3.1 Target Structure
 
-```
+```text
 src/antibody_training_esm/
 ├── core/
 │   ├── embeddings.py          # ESM (existing)
@@ -159,8 +159,8 @@ class BiophysicalExtractor:
         # Clean and validate sequence
         seq = sequence.upper().strip().replace("*", "")
 
-        # Biopython valid amino acids (excludes B, J, O, U, Z)
-        valid_aas = set("ACDEFGHIKLMNPQRSTVWXY")
+        # Biopython valid amino acids (standard 20 only - excludes X, B, J, O, U, Z)
+        valid_aas = set("ACDEFGHIKLMNPQRSTVWY")
         invalid = set(seq) - valid_aas
         if invalid:
             raise ValueError(

--- a/docs/to_do/biophysical_descriptors/PHASE_A_BIOPYTHON_TRIO.md
+++ b/docs/to_do/biophysical_descriptors/PHASE_A_BIOPYTHON_TRIO.md
@@ -65,7 +65,7 @@ uv run ruff check src/antibody_training_esm/core/biophysical.py
 
 ### Why pH 6 vs pH 7.4 Matters
 
-```
+```text
 Blood (pH 7.4)          Endosome (pH 6.0)
      │                        │
      ▼                        ▼
@@ -92,21 +92,20 @@ The **charge difference** between pH 6 and 7.4 affects:
 | File | Purpose |
 |------|---------|
 | `src/antibody_training_esm/core/biophysical.py` | Implementation |
-| `tests/unit/core/test_biophysical.py` | Unit tests |
-| `tests/fixtures/known_sequences.py` | Test sequences with known pI |
+| `tests/unit/core/test_biophysical.py` | Unit tests + test sequences (TRASTUZUMAB_VH, ACIDIC_SEQUENCE, etc.) |
 
 ---
 
 ## Acceptance Criteria
 
-- [ ] `BiophysicalExtractor` class exists
-- [ ] `extract_features(sequence)` returns (3,) numpy array
-- [ ] `extract_batch_features(sequences)` returns (n, 3) numpy array
-- [ ] Feature order: [charge_pH6, charge_pH7.4, pI]
-- [ ] All 12+ unit tests pass
-- [ ] mypy strict passes
-- [ ] ruff passes
-- [ ] Coverage ≥ 90%
+- [x] `BiophysicalExtractor` class exists
+- [x] `extract_features(sequence)` returns (3,) numpy array
+- [x] `extract_batch_features(sequences)` returns (n, 3) numpy array
+- [x] Feature order: [charge_pH6, charge_pH7.4, pI]
+- [x] All 30 unit tests pass
+- [x] mypy strict passes
+- [x] ruff passes
+- [ ] Coverage ≥ 90% (currently 81.63%)
 
 ---
 

--- a/src/antibody_training_esm/core/biophysical.py
+++ b/src/antibody_training_esm/core/biophysical.py
@@ -59,7 +59,7 @@ class BiophysicalExtractor:
 
     # Valid amino acids for Biopython ProteinAnalysis
     # NOTE: Unlike ESM, Biopython does NOT support 'X' (ambiguous)
-    # Standard 20 amino acids + selenocysteine (U) which Biopython handles
+    # Standard 20 amino acids only
     VALID_AMINO_ACIDS: set[str] = set("ACDEFGHIKLMNPQRSTVWY")
 
     def __init__(self) -> None:

--- a/tests/unit/core/test_biophysical.py
+++ b/tests/unit/core/test_biophysical.py
@@ -279,6 +279,28 @@ def test_rejects_empty_batch(extractor: BiophysicalExtractor) -> None:
         extractor.extract_batch_features([])
 
 
+@pytest.mark.unit
+def test_batch_rejects_invalid_sequence_with_index(
+    extractor: BiophysicalExtractor,
+) -> None:
+    """Verify batch extraction reports index of invalid sequence."""
+    sequences = [ACIDIC_SEQUENCE, "INVALIDXSEQ", BASIC_SEQUENCE]
+
+    with pytest.raises(ValueError, match="Invalid sequence at index 1"):
+        extractor.extract_batch_features(sequences)
+
+
+@pytest.mark.unit
+def test_batch_progress_logging(extractor: BiophysicalExtractor) -> None:
+    """Verify batch extraction handles 100+ sequences with progress logging."""
+    # Create 105 sequences to trigger progress logging at 100
+    sequences = [ACIDIC_SEQUENCE] * 105
+
+    features = extractor.extract_batch_features(sequences)
+
+    assert features.shape == (105, 3)
+
+
 # ============================================================================
 # Input Normalization Tests
 # ============================================================================
@@ -352,3 +374,5 @@ def test_long_sequence(extractor: BiophysicalExtractor) -> None:
     features = extractor.extract_features(long_sequence)
 
     assert features.shape == (3,)
+    assert not np.isnan(features).any(), "Features should not contain NaN"
+    assert not np.isinf(features).any(), "Features should not contain Inf"


### PR DESCRIPTION
## Summary

Implements the **3 FREE Biopython descriptors** from Sakhnini et al. 2025 (Novo Nordisk), Table S1:

| Paper # | Descriptor | Method | Expected Impact |
|---------|------------|--------|-----------------|
| #21 | Charge at pH 6.0 | `charge_at_pH(6.0)` | Endosomal behavior |
| #22 | Charge at pH 7.4 | `charge_at_pH(7.4)` | Blood/plasma behavior |
| #66 | Theoretical pI | `isoelectric_point()` | **65.2% accuracy alone** |

**Key Finding**: These are the ONLY 3 descriptors from Track B that don't require Schrödinger BioLuminate (~$5-20K/year license). The other 65 descriptors are blocked by licensing.

Closes #4

## Changes

- **`src/antibody_training_esm/core/biophysical.py`** (188 lines)
  - `BiophysicalExtractor` class with `extract_features()` and `extract_batch_features()`
  - Input validation (standard 20 AAs only, no 'X' ambiguous)
  - Proper normalization (uppercase, strip whitespace, remove stop codons)

- **`tests/unit/core/test_biophysical.py`** (354 lines)
  - 30 comprehensive TDD unit tests
  - Scientific validation (acidic→low pI, basic→high pI, charge↑ at lower pH)
  - Edge cases (single AA, long sequences, all 20 standard AAs)

- **`docs/to_do/biophysical_descriptors/`** - Implementation specs aligned with GitHub Issue #4

## Verification

```bash
# All tests pass
uv run pytest tests/unit/core/test_biophysical.py -v  # 30 passed

# Full suite regression check
uv run pytest -m "not e2e"  # 665 passed

# Type safety
uv run mypy src/antibody_training_esm/core/biophysical.py --strict  # Pass

# Linting
uv run ruff check src/antibody_training_esm/core/biophysical.py  # Clean
```

## Test Plan

- [x] 30 unit tests covering initialization, single/batch extraction, scientific validation, input validation, edge cases
- [x] mypy strict passes
- [x] ruff lint/format passes
- [x] Full test suite (665 tests) passes with no regressions
- [ ] CodeRabbit review

## Next Steps (Phase B - not in this PR)

1. Integration with `BinaryClassifier` (optional `feature_extractor` param)
2. Training on Boughter VH sequences to verify ~65% accuracy baseline
3. Testing on Jain dataset to compare with ESM's 71%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added biophysical descriptor extraction for protein sequences: Charge at pH 6.0, Charge at pH 7.4, and theoretical isoelectric point; includes single-item and batch processing, validation, and robust error reporting.

* **Documentation**
  * Added Phase A implementation and specification documents outlining design, API surface, test plans, and roadmap for future phases.

* **Tests**
  * Added comprehensive unit tests covering functionality, validation, edge cases, and scientific expectations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->